### PR TITLE
commit message shellescaped, thus, injection is prevented

### DIFF
--- a/CI_Git.php
+++ b/CI_Git.php
@@ -263,7 +263,7 @@ class GitRepo {
 	 * @return  string
 	 */	
 	public function commit($message = "") {
-		return $this->run("commit -av -m \"$message\"");
+		return $this->run("commit -av -m ".escapeshellarg($message));
 	}
 
 	/**

--- a/Git.php
+++ b/Git.php
@@ -256,7 +256,7 @@ class GitRepo {
 	 * @return  string
 	 */
 	public function commit($message = "") {
-		return $this->run("commit -av -m \"$message\"");
+		return $this->run("commit -av -m ".escapeshellarg($message));
 	}
 
 	/**


### PR DESCRIPTION
e.g. messages which include " result in an error. by escaping the message the error and other injections can be prevented.
