### PR TITLE
git status + bugfix

### DIFF
--- a/Git.php
+++ b/Git.php
@@ -387,7 +387,7 @@ class GitRepo {
 	 * @return  string
 	 */
 	public function clean($dirs = false, $force = false) {
-		return $this->run("clean".(($force) ? "-f" : "").(($dirs) ? " -d" : ""));
+		return $this->run("clean".(($force) ? " -f" : "").(($dirs) ? " -d" : ""));
 	}
 
 	/**


### PR DESCRIPTION
This PR does 2 things:
1. I was getting a `Parse Error` when using the `parse_ini` function that way, so I split it into 2 steps.
2. I added a method to run `git status`, passing `true` outputs the result with line breaks set properly.
