### PR TITLE
Fixed Git.pho commit error in flags

### DIFF
--- a/Git.php
+++ b/Git.php
@@ -377,7 +377,7 @@ class GitRepo {
 	 */
 	public function commit($message = "", $commit_all = true) {
 		$flags = $commit_all ? '-av' : '-v';
-		return $this->run("commit '.$flags.' -m ".escapeshellarg($message));
+		return $this->run("commit ".$flags." -m ".escapeshellarg($message));
 	}
 
 	/**


### PR DESCRIPTION
There is an error in the commit command caused by bad $flags sting concat.
