### PR TITLE
Quoting the  for add_tag

### DIFF
--- a/Git.php
+++ b/Git.php
@@ -571,7 +571,7 @@ class GitRepo {
 		if ($message === null) {
 			$message = $tag;
 		}
-		return $this->run("tag -a $tag -m '$message'");
+		return $this->run("tag -a $tag -m " . escapeshellarg($message));
 	}
 
 	/**

--- a/Git.php
+++ b/Git.php
@@ -571,7 +571,7 @@ class GitRepo {
 		if ($message === null) {
 			$message = $tag;
 		}
-		return $this->run("tag -a $tag -m $message");
+		return $this->run("tag -a $tag -m '$message'");
 	}
 
 	/**


### PR DESCRIPTION
Hey, I was running into an issue where `add_tag`  was throwing the following error:

```
exception 'Exception' with message 'fatal: too many params' in /var/docroot/flow/src/Fcl/Alfred/Git/Git.php:300
```

Pretty sure it was related to just passing `$message` directly as the option value.
