### PR TITLE
Assume PHP can find git instead of hardcode path

### DIFF
--- a/Git.php
+++ b/Git.php
@@ -6,7 +6,7 @@
  * A PHP git library
  *
  * @package    Git.php
- * @version    0.1.4
+ * @version    0.1.5
  * @author     James Brumond
  * @copyright  Copyright 2013 James Brumond
  * @repo       http://github.com/kbjr/Git.php
@@ -31,7 +31,7 @@ class Git {
 	 *
 	 * @var string
 	 */
-	protected static $bin = '/usr/bin/git';
+	protected static $bin = 'git';
 
 	/**
 	 * Sets git executable path
@@ -47,13 +47,6 @@ class Git {
 	 */
 	public static function get_bin() {
 		return self::$bin;
-	}
-
-	/**
-	 * Sets up library for use in a default Windows environment
-	 */
-	public static function windows_mode() {
-		self::set_bin('git');
 	}
 
 	/**


### PR DESCRIPTION
1) Assume PHP can find git path instead of hardcoding /usr/bin/git
  * For PHP-FPM this is set in the config with a line like

  `env[PATH] = /usr/local/bin:/usr/bin:/bin`

2) Remove redundant `windows_mode()` which is now the default behaviour

3) Bump version