### PR TITLE
Allowing extra flags while committing

### DIFF
--- a/Git.php
+++ b/Git.php
@@ -409,8 +409,9 @@ class GitRepo {
 	 * @param   boolean  should all files be committed automatically (-a flag)
 	 * @return  string
 	 */
-	public function commit($message = "", $commit_all = true) {
+	public function commit($message = "", $commit_all = true, $other_flags) {
 		$flags = $commit_all ? '-av' : '-v';
+		$flags .= ' ' . $other_flags;
 		return $this->run("commit ".$flags." -m ".escapeshellarg($message));
 	}
 

--- a/Git.php
+++ b/Git.php
@@ -407,6 +407,7 @@ class GitRepo {
 	 * @access  public
 	 * @param   string  commit message
 	 * @param   boolean  should all files be committed automatically (-a flag)
+	 * @param   string  extra flags to pass, eg: `--allow-empty`
 	 * @return  string
 	 */
 	public function commit($message = "", $commit_all = true, $other_flags) {


### PR DESCRIPTION
In an existing projects we are having issues while committing things because some times the commits happen when there are no staged changes. By passing the flag `--allow-empty` that would be fixed.

This PR is just for being able to pass extra flags to the commit method.