### PR TITLE
Added a Constructor for checking Git location

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -29,7 +29,19 @@ class Git
 	 *
 	 * @var string
 	 */
-	protected static $bin = '/usr/bin/git';
+	protected static $bin;
+
+	/**
+	 * Constructor
+	 *
+	 */
+
+	function __construct()
+	{
+		if(file_exists('/usr/bin/git'))
+		{self::$bin = '/usr/bin/git';}
+		else{self::$bin = 'git';}
+	}
 
 	/**
 	 * Sets git executable path


### PR DESCRIPTION
This modification allows XAMPP users to use the library , Since ,windows git path is not located in 'bin/user/git' . This return an error . 

Solution : A Constructor and 3 line code to check whether  'bin/user/git' is located or else use git from chmod in linux or %PATH% in windows